### PR TITLE
chore: update requirements to WordPress 6.8+ and PHP 8.3 in multiple files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.3.1
+- Update: Requires WordPress 6.8+ (tested up to 6.9)
+- Update: Requires PHP 8.3+
+
 ## 2.3.0
 - Feature: Cloudflare Browser Rendering integration for professional PDF generation via headless Chromium
 - Feature: Settings UI for Cloudflare Account ID and API Token with connection testing

--- a/README.md
+++ b/README.md
@@ -93,10 +93,10 @@ Select multiple posts and pages from your admin area and export them as:
 
 ## 💻 System Requirements
 
-- ✅ **WordPress 6.5+**
-- ✅ **PHP 8.2+** 
+- ✅ **WordPress 6.8+**
+- ✅ **PHP 8.3+** 
 - ✅ **Zip extension** (for bulk exports)
-- ✅ **Tested up to WordPress 6.8**
+- ✅ **Tested up to WordPress 6.9**
 
 *All required libraries are bundled - no additional setup needed!*
 

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
 	"type": "project",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"php": ">=8.2",
+		"php": ">=8.3",
 		"mpdf/mpdf": "^8.2",
 		"grandt/phpepub": "^4.0",
 		"yahnis-elsts/plugin-update-checker": "^5.0"

--- a/read-offline.php
+++ b/read-offline.php
@@ -6,11 +6,11 @@
  * @wordpress-plugin
  * Plugin Name:       Read Offline
  * Description:       Export posts and pages to PDF, EPUB, and Markdown for offline reading or reuse.
- * Version:           2.3.0
+ * Version:           2.3.1
  * Author:            Per Soderlind
  * Text Domain:       read-offline
- * Requires at least: 6.5
- * Requires PHP:      8.2
+ * Requires at least: 6.8
+ * Requires PHP:      8.3
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,10 @@
 === Read Offline ===
 Contributors: PerS
 Tags: pdf, epub, export, offline, download, markdown, bulk-export, documents
-Requires at least: 6.5
-Tested up to: 6.8
-Requires PHP: 8.2
-Stable tag: 2.3.0
+Requires at least: 6.8
+Tested up to: 6.9
+Requires PHP: 8.3
+Stable tag: 2.3.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -132,6 +132,10 @@ Check out HOOKS.md for 50+ customization filters and actions.
 5. **EPUB Reader View** - Publishing-quality e-books compatible with all major e-readers
 
 == Changelog ==
+
+= 2.3.1 - Requirements Update =
+* **Update**: Requires WordPress 6.8+ (tested up to 6.9)
+* **Update**: Requires PHP 8.3+
 
 = 2.2.7 - Queue-Aware REST Hooks & Cloudflare PDF =
 **Enhanced Export Processing**


### PR DESCRIPTION

- CHANGELOG.md: Added version 2.3.1 with updated requirements.
- README.md: Updated system requirements to reflect WordPress 6.8+ and PHP 8.3+.
- composer.json: Changed PHP requirement from 8.2 to 8.3.
- read-offline.php: Updated plugin version to 2.3.1 and modified required versions.
- readme.txt: Updated requirements and stable tag to 2.3.1.